### PR TITLE
bugfix on overlay select titles

### DIFF
--- a/components/overlayselecttiles/index.js
+++ b/components/overlayselecttiles/index.js
@@ -50,7 +50,9 @@ module.exports = {
             {
                 onclick: (e) => {
                     const value = getDataValue(e.target);
-                    attrs.onchange(value);
+                    if (value) { // e.target can be the container element with no "data-value" attribute
+                        attrs.onchange(value);
+                    }
                 }
             },
             attrs.options.map((tile) =>


### PR DESCRIPTION
when user clicks on a tile and then drags the mousepointer to another tile without releasing the click, e.target.value will be the tiles-container. this leads to a null value and further errors.